### PR TITLE
Add support to any kind JsonElement on RenderValue

### DIFF
--- a/AJP.JsonElementExtensions/JsonElementExtensions.cs
+++ b/AJP.JsonElementExtensions/JsonElementExtensions.cs
@@ -301,12 +301,7 @@ namespace AJP
                     writer.WriteStringValue(v);
                     break;
                 case JsonElement v:
-                    writer.WriteStartObject();
-                    foreach (var jProp in v.EnumerateObject())
-                    {
-                        jProp.WriteTo(writer);
-                    }
-                    writer.WriteEndObject();
+                    v.WriteTo(writer);
                     break;
                 case IEnumerable<object> arr:
                     writer.WriteStartArray();


### PR DESCRIPTION
Currently, JsonElement in RenderValue only supports Object Kind.
This change can support JsonElement of array, string, number, true, false kind.